### PR TITLE
dev-back 카카오 즉시 회원가입 및 로그인으로 수정

### DIFF
--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+dist

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,22 @@
+#  Define from what image we want to build from
+FROM node:16-alpine
+
+# Create a directory to hold the application code inside the image
+WORKDIR /oxo/src/app
+
+COPY package*.json ./
+
+# Install app dependencies
+RUN npm install
+
+# Bundle app source
+COPY . .
+
+# Bundle app's source code inside the Docker image
+RUN npm run build
+
+# Bind port
+EXPOSE 8080
+
+# Define commands to run app during runtime
+CMD ["node", "dist/main"]

--- a/server/src/auth/strategy/kakao.strategy.ts
+++ b/server/src/auth/strategy/kakao.strategy.ts
@@ -30,10 +30,10 @@ export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
       const user = await this.authService.validateUser(kakaoEmail);
       // console.log('user from strategy: ', user);
       if (!user) {
-        const onceToken = this.authService.onceToken(userProfile);
-        const result = await this.authService.addUser(userProfile);
+        // const onceToken = this.authService.onceToken(userProfile);
+        await this.authService.addUser(userProfile);
         // console.log(result);
-        return { onceToken, message: result, type: 'onceToken' };
+        // return { onceToken, message: result, type: 'onceToken' };
       }
 
       const accessToken = await this.authService.createLoginToken(user);


### PR DESCRIPTION
📑 작업내역 요약
소셜로그인시 oncetoken 삭제
즉시 로그인


✔️ 셀프 체크리스트

[x] Warning Message가 발생하지 않았나요?  
[x] Coding Convention을 준수했나요?  



💬 작업 내용


구현 내용 및 작업 했던 내역

(작업 내역 1)  kakaostrategy 수정
(작업 내역 1)  카카오 동의한 유저는 즉시 회원가입
(작업 내역 2)  최초 가입시 동의 이후 메인 페이지에서 로그아웃 버튼 보이도록 수정

🚧 PR 특이 사항  
